### PR TITLE
feat(email): add unified emails package with multiple providers

### DIFF
--- a/packages/emails/package.json
+++ b/packages/emails/package.json
@@ -1,0 +1,93 @@
+{
+  "name": "@rectangular-labs/emails",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "description": "Unified email client with multiple provider drivers",
+  "keywords": [
+    "rectangular-labs",
+    "email",
+    "smtp",
+    "sendgrid",
+    "resend",
+    "postmark"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ElasticBottle/rectangular-labs.git",
+    "directory": "packages/emails"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/ElasticBottle/rectangular-labs/tree/main/packages/emails#readme",
+  "files": [
+    "dist",
+    "!dist/**/*.map",
+    "README.md"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./drivers/*": {
+      "types": "./dist/drivers/*.d.ts",
+      "import": "./dist/drivers/*.js"
+    },
+    "./templates/*": {
+      "import": "./src/templates/*.tsx"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "clean": "git clean -xdf .turbo node_modules dist .cache",
+    "format": "pnpx @biomejs/biome format . --write",
+    "lint": "pnpx @biomejs/biome lint . --write",
+    "typecheck": "tsc --noEmit --emitDeclarationOnly false"
+  },
+  "devDependencies": {
+    "@rectangular-labs/typescript": "workspace:*",
+    "tsup": "^8.5.0",
+    "typescript": "^5.9.2"
+  },
+  "peerDependencies": {
+    "@aws-sdk/client-sesv2": "^3.0.0",
+    "@jsx-email/all": "^1.0.0",
+    "@plunk/node": "^3.0.0",
+    "@sendgrid/mail": "^8.0.0",
+    "mailersend": "^2.0.0",
+    "nodemailer": "^6.0.0",
+    "postmark": "^4.0.0",
+    "react": "^18.0.0",
+    "resend": "^4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@aws-sdk/client-sesv2": {
+      "optional": true
+    },
+    "@jsx-email/all": {
+      "optional": true
+    },
+    "@plunk/node": {
+      "optional": true
+    },
+    "@sendgrid/mail": {
+      "optional": true
+    },
+    "mailersend": {
+      "optional": true
+    },
+    "nodemailer": {
+      "optional": true
+    },
+    "postmark": {
+      "optional": true
+    },
+    "react": {
+      "optional": true
+    },
+    "resend": {
+      "optional": true
+    }
+  }
+}

--- a/packages/emails/src/client.ts
+++ b/packages/emails/src/client.ts
@@ -1,0 +1,24 @@
+import type { EmailClient, EmailDriver, EmailOptions, EmailResult } from "./types.js";
+
+export interface EmailClientConfig {
+  driver: EmailDriver;
+}
+
+class EmailClientImpl implements EmailClient {
+  constructor(private driver: EmailDriver) {}
+
+  async send(options: EmailOptions): Promise<EmailResult> {
+    try {
+      return await this.driver.send(options);
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : "Unknown error occurred"
+      };
+    }
+  }
+}
+
+export function createEmailClient(config: EmailClientConfig): EmailClient {
+  return new EmailClientImpl(config.driver);
+}

--- a/packages/emails/src/drivers/aws-ses.ts
+++ b/packages/emails/src/drivers/aws-ses.ts
@@ -1,0 +1,84 @@
+import type { EmailDriver, EmailOptions, EmailResult, AwsSesConfig, EmailAddress } from "../types.js";
+
+function normalizeEmailAddress(addr: string | EmailAddress): string {
+  if (typeof addr === "string") return addr;
+  return addr.name ? `"${addr.name}" <${addr.address}>` : addr.address;
+}
+
+function normalizeEmailAddresses(addrs?: string | string[] | EmailAddress | EmailAddress[]): string[] {
+  if (!addrs) return [];
+  if (Array.isArray(addrs)) {
+    return addrs.map(normalizeEmailAddress);
+  }
+  return [normalizeEmailAddress(addrs)];
+}
+
+export function awsSesDriver(config: AwsSesConfig): EmailDriver {
+  return {
+    name: "aws-ses",
+    async send(options: EmailOptions): Promise<EmailResult> {
+      try {
+        const { SESv2Client, SendEmailCommand } = await import("@aws-sdk/client-sesv2");
+        
+        const client = new SESv2Client({
+          region: config.region,
+          ...(config.accessKeyId && config.secretAccessKey && {
+            credentials: {
+              accessKeyId: config.accessKeyId,
+              secretAccessKey: config.secretAccessKey,
+            },
+          }),
+        });
+
+        const toAddresses = normalizeEmailAddresses(options.to);
+        const ccAddresses = normalizeEmailAddresses(options.cc);
+        const bccAddresses = normalizeEmailAddresses(options.bcc);
+
+        const command = new SendEmailCommand({
+          FromEmailAddress: config.fromEmail || normalizeEmailAddress(options.from),
+          Destination: {
+            ToAddresses: toAddresses,
+            ...(ccAddresses.length > 0 && { CcAddresses: ccAddresses }),
+            ...(bccAddresses.length > 0 && { BccAddresses: bccAddresses }),
+          },
+          Content: {
+            Simple: {
+              Subject: {
+                Data: options.subject,
+                Charset: "UTF-8",
+              },
+              Body: {
+                ...(options.html && {
+                  Html: {
+                    Data: options.html,
+                    Charset: "UTF-8",
+                  },
+                }),
+                ...(options.text && {
+                  Text: {
+                    Data: options.text,
+                    Charset: "UTF-8",
+                  },
+                }),
+              },
+            },
+          },
+          ...(options.replyTo && {
+            ReplyToAddresses: [normalizeEmailAddress(options.replyTo)],
+          }),
+        });
+
+        const result = await client.send(command);
+        return {
+          success: true,
+          messageId: result.MessageId,
+        };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : "Failed to send email via AWS SES",
+        };
+      }
+    },
+  };
+}

--- a/packages/emails/src/drivers/index.ts
+++ b/packages/emails/src/drivers/index.ts
@@ -1,0 +1,17 @@
+export { awsSesDriver } from "./aws-ses.js";
+export { mailersendDriver } from "./mailersend.js";
+export { nodemailerDriver } from "./nodemailer.js";
+export { postmarkDriver } from "./postmark.js";
+export { resendDriver } from "./resend.js";
+export { sendgridDriver } from "./sendgrid.js";
+export { plunkDriver } from "./plunk.js";
+
+export type {
+  AwsSesConfig,
+  MailersendConfig,
+  NodemailerConfig,
+  PostmarkConfig,
+  ResendConfig,
+  SendgridConfig,
+  PlunkConfig,
+} from "../types.js";

--- a/packages/emails/src/drivers/mailersend.ts
+++ b/packages/emails/src/drivers/mailersend.ts
@@ -1,0 +1,76 @@
+import type { EmailDriver, EmailOptions, EmailResult, MailersendConfig, EmailAddress } from "../types.js";
+
+function normalizeEmailAddress(addr: string | EmailAddress): { email: string; name?: string } {
+  if (typeof addr === "string") return { email: addr };
+  return { email: addr.address, ...(addr.name && { name: addr.name }) };
+}
+
+function normalizeEmailAddresses(addrs?: string | string[] | EmailAddress | EmailAddress[]): { email: string; name?: string }[] {
+  if (!addrs) return [];
+  if (Array.isArray(addrs)) {
+    return addrs.map(normalizeEmailAddress);
+  }
+  return [normalizeEmailAddress(addrs)];
+}
+
+export function mailersendDriver(config: MailersendConfig): EmailDriver {
+  return {
+    name: "mailersend",
+    async send(options: EmailOptions): Promise<EmailResult> {
+      try {
+        const { MailerSend, EmailParams, Sender, Recipient } = await import("mailersend");
+        
+        const mailerSend = new MailerSend({
+          apiKey: config.apiKey,
+        });
+
+        const fromAddr = normalizeEmailAddress(options.from);
+        const sentFrom = new Sender(fromAddr.email, fromAddr.name);
+
+        const toAddresses = normalizeEmailAddresses(options.to);
+        const recipients = toAddresses.map(addr => new Recipient(addr.email, addr.name));
+
+        const emailParams = new EmailParams()
+          .setFrom(sentFrom)
+          .setTo(recipients)
+          .setSubject(options.subject);
+
+        if (options.html) {
+          emailParams.setHtml(options.html);
+        }
+
+        if (options.text) {
+          emailParams.setText(options.text);
+        }
+
+        if (options.cc) {
+          const ccAddresses = normalizeEmailAddresses(options.cc);
+          const ccRecipients = ccAddresses.map(addr => new Recipient(addr.email, addr.name));
+          emailParams.setCc(ccRecipients);
+        }
+
+        if (options.bcc) {
+          const bccAddresses = normalizeEmailAddresses(options.bcc);
+          const bccRecipients = bccAddresses.map(addr => new Recipient(addr.email, addr.name));
+          emailParams.setBcc(bccRecipients);
+        }
+
+        if (options.replyTo) {
+          const replyToAddr = normalizeEmailAddress(options.replyTo);
+          emailParams.setReplyTo(new Recipient(replyToAddr.email, replyToAddr.name));
+        }
+
+        const result = await mailerSend.email.send(emailParams);
+        return {
+          success: true,
+          messageId: result.headers?.["x-message-id"] as string,
+        };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : "Failed to send email via MailerSend",
+        };
+      }
+    },
+  };
+}

--- a/packages/emails/src/drivers/nodemailer.ts
+++ b/packages/emails/src/drivers/nodemailer.ts
@@ -1,0 +1,62 @@
+import type { EmailDriver, EmailOptions, EmailResult, NodemailerConfig, EmailAddress } from "../types.js";
+
+function normalizeEmailAddress(addr: string | EmailAddress): string {
+  if (typeof addr === "string") return addr;
+  return addr.name ? `"${addr.name}" <${addr.address}>` : addr.address;
+}
+
+function normalizeEmailAddresses(addrs?: string | string[] | EmailAddress | EmailAddress[]): string | string[] {
+  if (!addrs) return [];
+  if (Array.isArray(addrs)) {
+    return addrs.map(normalizeEmailAddress);
+  }
+  return normalizeEmailAddress(addrs);
+}
+
+export function nodemailerDriver(config: NodemailerConfig): EmailDriver {
+  return {
+    name: "nodemailer",
+    async send(options: EmailOptions): Promise<EmailResult> {
+      try {
+        const nodemailer = await import("nodemailer");
+        
+        const transporter = nodemailer.default.createTransporter({
+          host: config.host,
+          port: config.port,
+          secure: config.secure,
+          auth: config.auth,
+        });
+
+        const mailOptions = {
+          from: normalizeEmailAddress(options.from),
+          to: normalizeEmailAddresses(options.to),
+          subject: options.subject,
+          ...(options.html && { html: options.html }),
+          ...(options.text && { text: options.text }),
+          ...(options.cc && { cc: normalizeEmailAddresses(options.cc) }),
+          ...(options.bcc && { bcc: normalizeEmailAddresses(options.bcc) }),
+          ...(options.replyTo && { replyTo: normalizeEmailAddress(options.replyTo) }),
+          ...(options.attachments && {
+            attachments: options.attachments.map(att => ({
+              filename: att.filename,
+              content: att.content,
+              contentType: att.contentType,
+              encoding: att.encoding,
+            })),
+          }),
+        };
+
+        const info = await transporter.sendMail(mailOptions);
+        return {
+          success: true,
+          messageId: info.messageId,
+        };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : "Failed to send email via Nodemailer",
+        };
+      }
+    },
+  };
+}

--- a/packages/emails/src/drivers/plunk.ts
+++ b/packages/emails/src/drivers/plunk.ts
@@ -1,0 +1,49 @@
+import type { EmailDriver, EmailOptions, EmailResult, PlunkConfig, EmailAddress } from "../types.js";
+
+function normalizeEmailAddress(addr: string | EmailAddress): string {
+  if (typeof addr === "string") return addr;
+  return addr.name ? `"${addr.name}" <${addr.address}>` : addr.address;
+}
+
+function normalizeEmailAddresses(addrs?: string | string[] | EmailAddress | EmailAddress[]): string[] {
+  if (!addrs) return [];
+  if (Array.isArray(addrs)) {
+    return addrs.map(normalizeEmailAddress);
+  }
+  return [normalizeEmailAddress(addrs)];
+}
+
+export function plunkDriver(config: PlunkConfig): EmailDriver {
+  return {
+    name: "plunk",
+    async send(options: EmailOptions): Promise<EmailResult> {
+      try {
+        const { Plunk } = await import("@plunk/node");
+        
+        const plunk = new Plunk(config.apiKey);
+
+        const toAddresses = normalizeEmailAddresses(options.to);
+        
+        const email = {
+          from: normalizeEmailAddress(options.from),
+          to: toAddresses[0], // Plunk typically sends to one recipient at a time
+          subject: options.subject,
+          ...(options.html && { html: options.html }),
+          ...(options.text && { text: options.text }),
+          ...(options.replyTo && { replyTo: normalizeEmailAddress(options.replyTo) }),
+        };
+
+        const result = await plunk.emails.send(email);
+        return {
+          success: true,
+          messageId: result.id,
+        };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : "Failed to send email via Plunk",
+        };
+      }
+    },
+  };
+}

--- a/packages/emails/src/drivers/postmark.ts
+++ b/packages/emails/src/drivers/postmark.ts
@@ -1,0 +1,57 @@
+import { Buffer } from "node:buffer";
+import type { EmailDriver, EmailOptions, EmailResult, PostmarkConfig, EmailAddress } from "../types.js";
+
+function normalizeEmailAddress(addr: string | EmailAddress): string {
+  if (typeof addr === "string") return addr;
+  return addr.name ? `"${addr.name}" <${addr.address}>` : addr.address;
+}
+
+function normalizeEmailAddresses(addrs?: string | string[] | EmailAddress | EmailAddress[]): string {
+  if (!addrs) return "";
+  if (Array.isArray(addrs)) {
+    return addrs.map(normalizeEmailAddress).join(",");
+  }
+  return normalizeEmailAddress(addrs);
+}
+
+export function postmarkDriver(config: PostmarkConfig): EmailDriver {
+  return {
+    name: "postmark",
+    async send(options: EmailOptions): Promise<EmailResult> {
+      try {
+        const { ServerClient } = await import("postmark");
+        
+        const client = new ServerClient(config.apiKey);
+
+        const email = {
+          From: normalizeEmailAddress(options.from),
+          To: normalizeEmailAddresses(options.to),
+          Subject: options.subject,
+          ...(options.html && { HtmlBody: options.html }),
+          ...(options.text && { TextBody: options.text }),
+          ...(options.cc && { Cc: normalizeEmailAddresses(options.cc) }),
+          ...(options.bcc && { Bcc: normalizeEmailAddresses(options.bcc) }),
+          ...(options.replyTo && { ReplyTo: normalizeEmailAddress(options.replyTo) }),
+          ...(options.attachments && {
+            Attachments: options.attachments.map(att => ({
+              Name: att.filename,
+              Content: typeof att.content === "string" ? att.content : Buffer.from(att.content).toString("base64"),
+              ContentType: att.contentType || "application/octet-stream",
+            })),
+          }),
+        };
+
+        const result = await client.sendEmail(email);
+        return {
+          success: true,
+          messageId: result.MessageID,
+        };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : "Failed to send email via Postmark",
+        };
+      }
+    },
+  };
+}

--- a/packages/emails/src/drivers/resend.ts
+++ b/packages/emails/src/drivers/resend.ts
@@ -1,0 +1,65 @@
+import { Buffer } from "node:buffer";
+import type { EmailDriver, EmailOptions, EmailResult, ResendConfig, EmailAddress } from "../types.js";
+
+function normalizeEmailAddress(addr: string | EmailAddress): string | { name?: string; email: string } {
+  if (typeof addr === "string") return addr;
+  return { email: addr.address, ...(addr.name && { name: addr.name }) };
+}
+
+function normalizeEmailAddresses(addrs?: string | string[] | EmailAddress | EmailAddress[]): (string | { name?: string; email: string })[] {
+  if (!addrs) return [];
+  if (Array.isArray(addrs)) {
+    return addrs.map(normalizeEmailAddress);
+  }
+  return [normalizeEmailAddress(addrs)];
+}
+
+export function resendDriver(config: ResendConfig): EmailDriver {
+  return {
+    name: "resend",
+    async send(options: EmailOptions): Promise<EmailResult> {
+      try {
+        const { Resend } = await import("resend");
+        
+        const resend = new Resend(config.apiKey);
+
+        const email = {
+          from: normalizeEmailAddress(options.from),
+          to: normalizeEmailAddresses(options.to),
+          subject: options.subject,
+          ...(options.html && { html: options.html }),
+          ...(options.text && { text: options.text }),
+          ...(options.cc && { cc: normalizeEmailAddresses(options.cc) }),
+          ...(options.bcc && { bcc: normalizeEmailAddresses(options.bcc) }),
+          ...(options.replyTo && { reply_to: normalizeEmailAddress(options.replyTo) }),
+          ...(options.attachments && {
+            attachments: options.attachments.map(att => ({
+              filename: att.filename,
+              content: typeof att.content === "string" ? Buffer.from(att.content) : Buffer.from(att.content),
+              contentType: att.contentType,
+            })),
+          }),
+        };
+
+        const result = await resend.emails.send(email);
+        
+        if (result.error) {
+          return {
+            success: false,
+            error: result.error.message,
+          };
+        }
+
+        return {
+          success: true,
+          messageId: result.data?.id,
+        };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : "Failed to send email via Resend",
+        };
+      }
+    },
+  };
+}

--- a/packages/emails/src/drivers/sendgrid.ts
+++ b/packages/emails/src/drivers/sendgrid.ts
@@ -1,0 +1,58 @@
+import { Buffer } from "node:buffer";
+import type { EmailDriver, EmailOptions, EmailResult, SendgridConfig, EmailAddress } from "../types.js";
+
+function normalizeEmailAddress(addr: string | EmailAddress): { email: string; name?: string } {
+  if (typeof addr === "string") return { email: addr };
+  return { email: addr.address, ...(addr.name && { name: addr.name }) };
+}
+
+function normalizeEmailAddresses(addrs?: string | string[] | EmailAddress | EmailAddress[]): { email: string; name?: string }[] {
+  if (!addrs) return [];
+  if (Array.isArray(addrs)) {
+    return addrs.map(normalizeEmailAddress);
+  }
+  return [normalizeEmailAddress(addrs)];
+}
+
+export function sendgridDriver(config: SendgridConfig): EmailDriver {
+  return {
+    name: "sendgrid",
+    async send(options: EmailOptions): Promise<EmailResult> {
+      try {
+        const sgMail = await import("@sendgrid/mail");
+        
+        sgMail.default.setApiKey(config.apiKey);
+
+        const msg = {
+          from: normalizeEmailAddress(options.from),
+          to: normalizeEmailAddresses(options.to),
+          subject: options.subject,
+          ...(options.html && { html: options.html }),
+          ...(options.text && { text: options.text }),
+          ...(options.cc && { cc: normalizeEmailAddresses(options.cc) }),
+          ...(options.bcc && { bcc: normalizeEmailAddresses(options.bcc) }),
+          ...(options.replyTo && { replyTo: normalizeEmailAddress(options.replyTo) }),
+          ...(options.attachments && {
+            attachments: options.attachments.map(att => ({
+              filename: att.filename,
+              content: typeof att.content === "string" ? att.content : Buffer.from(att.content).toString("base64"),
+              type: att.contentType,
+              disposition: "attachment",
+            })),
+          }),
+        };
+
+        const result = await sgMail.default.send(msg);
+        return {
+          success: true,
+          messageId: result[0]?.headers?.["x-message-id"] as string,
+        };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : "Failed to send email via SendGrid",
+        };
+      }
+    },
+  };
+}

--- a/packages/emails/src/index.ts
+++ b/packages/emails/src/index.ts
@@ -1,0 +1,10 @@
+export { createEmailClient } from "./client.js";
+export type { EmailClientConfig } from "./client.js";
+export type {
+  EmailOptions,
+  EmailResult,
+  EmailDriver,
+  EmailClient,
+  EmailAddress,
+  EmailAttachment,
+} from "./types.js";

--- a/packages/emails/src/templates/email-verification.tsx
+++ b/packages/emails/src/templates/email-verification.tsx
@@ -1,0 +1,139 @@
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Heading,
+  Html,
+  Img,
+  Link,
+  Preview,
+  Section,
+  Text,
+} from "@jsx-email/all";
+
+export interface EmailVerificationProps {
+  username: string;
+  verificationLink: string;
+  companyName?: string;
+  companyLogo?: string;
+}
+
+export const EmailVerificationEmail = ({
+  username = "there",
+  verificationLink,
+  companyName = "Our App",
+  companyLogo,
+}: EmailVerificationProps) => {
+  return (
+    <Html>
+      <Head />
+      <Preview>Please verify your email address</Preview>
+      <Body style={main}>
+        <Container style={container}>
+          {companyLogo && (
+            <Section style={logoSection}>
+              <Img
+                src={companyLogo}
+                width="40"
+                height="40"
+                alt={companyName}
+                style={logo}
+              />
+            </Section>
+          )}
+          <Heading style={h1}>Please verify your email</Heading>
+          <Text style={text}>Hi {username},</Text>
+          <Text style={text}>
+            Thanks for signing up for {companyName}! To complete your
+            registration, please verify your email address by clicking the
+            button below:
+          </Text>
+          <Section style={buttonSection}>
+            <Button pX={20} pY={12} style={button} href={verificationLink}>
+              Verify email address
+            </Button>
+          </Section>
+          <Text style={text}>
+            Or copy and paste this URL into your browser:{" "}
+            <Link href={verificationLink} style={link}>
+              {verificationLink}
+            </Link>
+          </Text>
+          <Text style={text}>
+            This verification link will expire in 24 hours. If you didn't create
+            an account with {companyName}, you can safely ignore this email.
+          </Text>
+          <Text style={footer}>
+            Need help? Contact our support team.
+          </Text>
+        </Container>
+      </Body>
+    </Html>
+  );
+};
+
+const main = {
+  backgroundColor: "#ffffff",
+  fontFamily:
+    '-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif',
+};
+
+const container = {
+  margin: "0 auto",
+  padding: "20px 0 48px",
+  maxWidth: "560px",
+};
+
+const logoSection = {
+  padding: "0 0 20px",
+  textAlign: "center" as const,
+};
+
+const logo = {
+  borderRadius: "8px",
+};
+
+const h1 = {
+  color: "#333",
+  fontSize: "24px",
+  fontWeight: "bold",
+  margin: "40px 0",
+  padding: "0",
+  textAlign: "center" as const,
+};
+
+const text = {
+  color: "#333",
+  fontSize: "14px",
+  lineHeight: "24px",
+  margin: "0 0 20px",
+};
+
+const buttonSection = {
+  textAlign: "center" as const,
+  margin: "32px 0",
+};
+
+const button = {
+  backgroundColor: "#3b82f6",
+  borderRadius: "6px",
+  color: "#ffffff",
+  fontSize: "16px",
+  textDecoration: "none",
+  textAlign: "center" as const,
+  display: "block",
+  width: "100%",
+};
+
+const link = {
+  color: "#067df7",
+  textDecoration: "underline",
+};
+
+const footer = {
+  color: "#898989",
+  fontSize: "12px",
+  lineHeight: "20px",
+  margin: "20px 0 0",
+};

--- a/packages/emails/src/templates/index.ts
+++ b/packages/emails/src/templates/index.ts
@@ -1,0 +1,17 @@
+export { MagicLinkEmail } from "./magic-link.js";
+export type { MagicLinkEmailProps } from "./magic-link.js";
+
+export { OtpEmail } from "./otp.js";
+export type { OtpEmailProps } from "./otp.js";
+
+export { PasswordResetEmail } from "./password-reset.js";
+export type { PasswordResetEmailProps } from "./password-reset.js";
+
+export { WelcomeEmail } from "./welcome.js";
+export type { WelcomeEmailProps } from "./welcome.js";
+
+export { UserInviteEmail } from "./user-invite.js";
+export type { UserInviteEmailProps } from "./user-invite.js";
+
+export { EmailVerificationEmail } from "./email-verification.js";
+export type { EmailVerificationProps } from "./email-verification.js";

--- a/packages/emails/src/templates/magic-link.tsx
+++ b/packages/emails/src/templates/magic-link.tsx
@@ -1,0 +1,134 @@
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Heading,
+  Html,
+  Img,
+  Link,
+  Preview,
+  Section,
+  Text,
+} from "@jsx-email/all";
+
+export interface MagicLinkEmailProps {
+  username: string;
+  magicLink: string;
+  companyName?: string;
+  companyLogo?: string;
+}
+
+export const MagicLinkEmail = ({
+  username = "there",
+  magicLink,
+  companyName = "Our App",
+  companyLogo,
+}: MagicLinkEmailProps) => {
+  return (
+    <Html>
+      <Head />
+      <Preview>Your magic link to sign in</Preview>
+      <Body style={main}>
+        <Container style={container}>
+          {companyLogo && (
+            <Section style={logoSection}>
+              <Img
+                src={companyLogo}
+                width="40"
+                height="40"
+                alt={companyName}
+                style={logo}
+              />
+            </Section>
+          )}
+          <Heading style={h1}>Sign in to {companyName}</Heading>
+          <Text style={text}>Hi {username},</Text>
+          <Text style={text}>
+            Click the link below to sign in to your account. This link will
+            expire in 10 minutes.
+          </Text>
+          <Section style={buttonSection}>
+            <Button pX={20} pY={12} style={button} href={magicLink}>
+              Sign in
+            </Button>
+          </Section>
+          <Text style={text}>
+            Or copy and paste this URL into your browser:{" "}
+            <Link href={magicLink} style={link}>
+              {magicLink}
+            </Link>
+          </Text>
+          <Text style={footer}>
+            If you didn't request this email, you can safely ignore it.
+          </Text>
+        </Container>
+      </Body>
+    </Html>
+  );
+};
+
+const main = {
+  backgroundColor: "#ffffff",
+  fontFamily:
+    '-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif',
+};
+
+const container = {
+  margin: "0 auto",
+  padding: "20px 0 48px",
+  maxWidth: "560px",
+};
+
+const logoSection = {
+  padding: "0 0 20px",
+  textAlign: "center" as const,
+};
+
+const logo = {
+  borderRadius: "8px",
+};
+
+const h1 = {
+  color: "#333",
+  fontSize: "24px",
+  fontWeight: "bold",
+  margin: "40px 0",
+  padding: "0",
+  textAlign: "center" as const,
+};
+
+const text = {
+  color: "#333",
+  fontSize: "14px",
+  lineHeight: "24px",
+  margin: "0 0 20px",
+};
+
+const buttonSection = {
+  textAlign: "center" as const,
+  margin: "32px 0",
+};
+
+const button = {
+  backgroundColor: "#000000",
+  borderRadius: "6px",
+  color: "#ffffff",
+  fontSize: "16px",
+  textDecoration: "none",
+  textAlign: "center" as const,
+  display: "block",
+  width: "100%",
+};
+
+const link = {
+  color: "#067df7",
+  textDecoration: "underline",
+};
+
+const footer = {
+  color: "#898989",
+  fontSize: "12px",
+  lineHeight: "20px",
+  margin: "20px 0 0",
+};

--- a/packages/emails/src/templates/otp.tsx
+++ b/packages/emails/src/templates/otp.tsx
@@ -1,0 +1,123 @@
+import {
+  Body,
+  Container,
+  Head,
+  Heading,
+  Html,
+  Img,
+  Preview,
+  Section,
+  Text,
+} from "@jsx-email/all";
+
+export interface OtpEmailProps {
+  username: string;
+  otp: string;
+  companyName?: string;
+  companyLogo?: string;
+}
+
+export const OtpEmail = ({
+  username = "there",
+  otp,
+  companyName = "Our App",
+  companyLogo,
+}: OtpEmailProps) => {
+  return (
+    <Html>
+      <Head />
+      <Preview>Your verification code: {otp}</Preview>
+      <Body style={main}>
+        <Container style={container}>
+          {companyLogo && (
+            <Section style={logoSection}>
+              <Img
+                src={companyLogo}
+                width="40"
+                height="40"
+                alt={companyName}
+                style={logo}
+              />
+            </Section>
+          )}
+          <Heading style={h1}>Your verification code</Heading>
+          <Text style={text}>Hi {username},</Text>
+          <Text style={text}>
+            Use the following verification code to complete your sign-in:
+          </Text>
+          <Section style={codeSection}>
+            <Text style={codeText}>{otp}</Text>
+          </Section>
+          <Text style={text}>
+            This code will expire in 10 minutes. If you didn't request this
+            code, you can safely ignore this email.
+          </Text>
+          <Text style={footer}>
+            Sent by {companyName}
+          </Text>
+        </Container>
+      </Body>
+    </Html>
+  );
+};
+
+const main = {
+  backgroundColor: "#ffffff",
+  fontFamily:
+    '-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif',
+};
+
+const container = {
+  margin: "0 auto",
+  padding: "20px 0 48px",
+  maxWidth: "560px",
+};
+
+const logoSection = {
+  padding: "0 0 20px",
+  textAlign: "center" as const,
+};
+
+const logo = {
+  borderRadius: "8px",
+};
+
+const h1 = {
+  color: "#333",
+  fontSize: "24px",
+  fontWeight: "bold",
+  margin: "40px 0",
+  padding: "0",
+  textAlign: "center" as const,
+};
+
+const text = {
+  color: "#333",
+  fontSize: "14px",
+  lineHeight: "24px",
+  margin: "0 0 20px",
+};
+
+const codeSection = {
+  background: "#f4f4f4",
+  border: "1px solid #eee",
+  borderRadius: "8px",
+  margin: "32px 0",
+  padding: "24px",
+  textAlign: "center" as const,
+};
+
+const codeText = {
+  fontSize: "32px",
+  fontWeight: "bold",
+  letterSpacing: "8px",
+  margin: "0",
+  fontFamily: "monospace",
+};
+
+const footer = {
+  color: "#898989",
+  fontSize: "12px",
+  lineHeight: "20px",
+  margin: "20px 0 0",
+};

--- a/packages/emails/src/templates/password-reset.tsx
+++ b/packages/emails/src/templates/password-reset.tsx
@@ -1,0 +1,142 @@
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Heading,
+  Html,
+  Img,
+  Link,
+  Preview,
+  Section,
+  Text,
+} from "@jsx-email/all";
+
+export interface PasswordResetEmailProps {
+  username: string;
+  resetLink: string;
+  companyName?: string;
+  companyLogo?: string;
+}
+
+export const PasswordResetEmail = ({
+  username = "there",
+  resetLink,
+  companyName = "Our App",
+  companyLogo,
+}: PasswordResetEmailProps) => {
+  return (
+    <Html>
+      <Head />
+      <Preview>Reset your password</Preview>
+      <Body style={main}>
+        <Container style={container}>
+          {companyLogo && (
+            <Section style={logoSection}>
+              <Img
+                src={companyLogo}
+                width="40"
+                height="40"
+                alt={companyName}
+                style={logo}
+              />
+            </Section>
+          )}
+          <Heading style={h1}>Reset your password</Heading>
+          <Text style={text}>Hi {username},</Text>
+          <Text style={text}>
+            Someone recently requested a password change for your {companyName}{" "}
+            account. If this was you, you can set a new password here:
+          </Text>
+          <Section style={buttonSection}>
+            <Button pX={20} pY={12} style={button} href={resetLink}>
+              Reset password
+            </Button>
+          </Section>
+          <Text style={text}>
+            Or copy and paste this URL into your browser:{" "}
+            <Link href={resetLink} style={link}>
+              {resetLink}
+            </Link>
+          </Text>
+          <Text style={text}>
+            If you don't want to change your password or didn't request this,
+            just ignore and delete this message.
+          </Text>
+          <Text style={text}>
+            To keep your account secure, please don't forward this email to
+            anyone.
+          </Text>
+          <Text style={footer}>
+            This password reset link will expire in 1 hour.
+          </Text>
+        </Container>
+      </Body>
+    </Html>
+  );
+};
+
+const main = {
+  backgroundColor: "#ffffff",
+  fontFamily:
+    '-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif',
+};
+
+const container = {
+  margin: "0 auto",
+  padding: "20px 0 48px",
+  maxWidth: "560px",
+};
+
+const logoSection = {
+  padding: "0 0 20px",
+  textAlign: "center" as const,
+};
+
+const logo = {
+  borderRadius: "8px",
+};
+
+const h1 = {
+  color: "#333",
+  fontSize: "24px",
+  fontWeight: "bold",
+  margin: "40px 0",
+  padding: "0",
+  textAlign: "center" as const,
+};
+
+const text = {
+  color: "#333",
+  fontSize: "14px",
+  lineHeight: "24px",
+  margin: "0 0 20px",
+};
+
+const buttonSection = {
+  textAlign: "center" as const,
+  margin: "32px 0",
+};
+
+const button = {
+  backgroundColor: "#dc2626",
+  borderRadius: "6px",
+  color: "#ffffff",
+  fontSize: "16px",
+  textDecoration: "none",
+  textAlign: "center" as const,
+  display: "block",
+  width: "100%",
+};
+
+const link = {
+  color: "#067df7",
+  textDecoration: "underline",
+};
+
+const footer = {
+  color: "#898989",
+  fontSize: "12px",
+  lineHeight: "20px",
+  margin: "20px 0 0",
+};

--- a/packages/emails/src/templates/user-invite.tsx
+++ b/packages/emails/src/templates/user-invite.tsx
@@ -1,0 +1,135 @@
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Heading,
+  Html,
+  Img,
+  Preview,
+  Section,
+  Text,
+} from "@jsx-email/all";
+
+export interface UserInviteEmailProps {
+  inviterName: string;
+  inviteeEmail: string;
+  teamName: string;
+  inviteLink: string;
+  companyName?: string;
+  companyLogo?: string;
+}
+
+export const UserInviteEmail = ({
+  inviterName,
+  inviteeEmail,
+  teamName,
+  inviteLink,
+  companyName = "Our App",
+  companyLogo,
+}: UserInviteEmailProps) => {
+  return (
+    <Html>
+      <Head />
+      <Preview>You've been invited to join {teamName}</Preview>
+      <Body style={main}>
+        <Container style={container}>
+          {companyLogo && (
+            <Section style={logoSection}>
+              <Img
+                src={companyLogo}
+                width="40"
+                height="40"
+                alt={companyName}
+                style={logo}
+              />
+            </Section>
+          )}
+          <Heading style={h1}>You've been invited to {teamName}</Heading>
+          <Text style={text}>Hi there,</Text>
+          <Text style={text}>
+            <strong>{inviterName}</strong> has invited you to join{" "}
+            <strong>{teamName}</strong> on {companyName}.
+          </Text>
+          <Section style={buttonSection}>
+            <Button pX={20} pY={12} style={button} href={inviteLink}>
+              Accept invitation
+            </Button>
+          </Section>
+          <Text style={text}>
+            This invitation was sent to <strong>{inviteeEmail}</strong>. If you
+            were not expecting this invitation, you can ignore this email.
+          </Text>
+          <Text style={text}>
+            If you already have an account with {companyName}, clicking the
+            button above will add you to the team. If you don't have an account,
+            you'll be able to create one.
+          </Text>
+          <Text style={footer}>
+            This invitation will expire in 7 days.
+          </Text>
+        </Container>
+      </Body>
+    </Html>
+  );
+};
+
+const main = {
+  backgroundColor: "#ffffff",
+  fontFamily:
+    '-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif',
+};
+
+const container = {
+  margin: "0 auto",
+  padding: "20px 0 48px",
+  maxWidth: "560px",
+};
+
+const logoSection = {
+  padding: "0 0 20px",
+  textAlign: "center" as const,
+};
+
+const logo = {
+  borderRadius: "8px",
+};
+
+const h1 = {
+  color: "#333",
+  fontSize: "24px",
+  fontWeight: "bold",
+  margin: "40px 0",
+  padding: "0",
+  textAlign: "center" as const,
+};
+
+const text = {
+  color: "#333",
+  fontSize: "14px",
+  lineHeight: "24px",
+  margin: "0 0 20px",
+};
+
+const buttonSection = {
+  textAlign: "center" as const,
+  margin: "32px 0",
+};
+
+const button = {
+  backgroundColor: "#000000",
+  borderRadius: "6px",
+  color: "#ffffff",
+  fontSize: "16px",
+  textDecoration: "none",
+  textAlign: "center" as const,
+  display: "block",
+  width: "100%",
+};
+
+const footer = {
+  color: "#898989",
+  fontSize: "12px",
+  lineHeight: "20px",
+  margin: "20px 0 0",
+};

--- a/packages/emails/src/templates/welcome.tsx
+++ b/packages/emails/src/templates/welcome.tsx
@@ -1,0 +1,133 @@
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Heading,
+  Html,
+  Img,
+  Preview,
+  Section,
+  Text,
+} from "@jsx-email/all";
+
+export interface WelcomeEmailProps {
+  username: string;
+  dashboardLink?: string;
+  companyName?: string;
+  companyLogo?: string;
+}
+
+export const WelcomeEmail = ({
+  username = "there",
+  dashboardLink,
+  companyName = "Our App",
+  companyLogo,
+}: WelcomeEmailProps) => {
+  return (
+    <Html>
+      <Head />
+      <Preview>Welcome to {companyName}!</Preview>
+      <Body style={main}>
+        <Container style={container}>
+          {companyLogo && (
+            <Section style={logoSection}>
+              <Img
+                src={companyLogo}
+                width="40"
+                height="40"
+                alt={companyName}
+                style={logo}
+              />
+            </Section>
+          )}
+          <Heading style={h1}>Welcome to {companyName}!</Heading>
+          <Text style={text}>Hi {username},</Text>
+          <Text style={text}>
+            Welcome to {companyName}! We're excited to have you on board.
+            You're now part of our community and can start exploring all the
+            features we have to offer.
+          </Text>
+          {dashboardLink && (
+            <Section style={buttonSection}>
+              <Button pX={20} pY={12} style={button} href={dashboardLink}>
+                Get started
+              </Button>
+            </Section>
+          )}
+          <Text style={text}>
+            If you have any questions or need help getting started, don't
+            hesitate to reach out to our support team.
+          </Text>
+          <Text style={text}>
+            Thanks for joining us, and welcome aboard!
+          </Text>
+          <Text style={signature}>
+            Best regards,<br />
+            The {companyName} Team
+          </Text>
+        </Container>
+      </Body>
+    </Html>
+  );
+};
+
+const main = {
+  backgroundColor: "#ffffff",
+  fontFamily:
+    '-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif',
+};
+
+const container = {
+  margin: "0 auto",
+  padding: "20px 0 48px",
+  maxWidth: "560px",
+};
+
+const logoSection = {
+  padding: "0 0 20px",
+  textAlign: "center" as const,
+};
+
+const logo = {
+  borderRadius: "8px",
+};
+
+const h1 = {
+  color: "#333",
+  fontSize: "24px",
+  fontWeight: "bold",
+  margin: "40px 0",
+  padding: "0",
+  textAlign: "center" as const,
+};
+
+const text = {
+  color: "#333",
+  fontSize: "14px",
+  lineHeight: "24px",
+  margin: "0 0 20px",
+};
+
+const buttonSection = {
+  textAlign: "center" as const,
+  margin: "32px 0",
+};
+
+const button = {
+  backgroundColor: "#22c55e",
+  borderRadius: "6px",
+  color: "#ffffff",
+  fontSize: "16px",
+  textDecoration: "none",
+  textAlign: "center" as const,
+  display: "block",
+  width: "100%",
+};
+
+const signature = {
+  color: "#333",
+  fontSize: "14px",
+  lineHeight: "24px",
+  margin: "32px 0 0",
+};

--- a/packages/emails/src/types.ts
+++ b/packages/emails/src/types.ts
@@ -1,0 +1,75 @@
+export interface EmailAddress {
+  name?: string;
+  address: string;
+}
+
+export interface EmailAttachment {
+  filename: string;
+  content: string | Uint8Array;
+  contentType?: string;
+  encoding?: string;
+}
+
+export interface EmailOptions {
+  from: string | EmailAddress;
+  to: string | string[] | EmailAddress | EmailAddress[];
+  subject: string;
+  html?: string;
+  text?: string;
+  cc?: string | string[] | EmailAddress | EmailAddress[];
+  bcc?: string | string[] | EmailAddress | EmailAddress[];
+  replyTo?: string | EmailAddress;
+  attachments?: EmailAttachment[];
+}
+
+export interface EmailResult {
+  success: boolean;
+  messageId?: string;
+  error?: string;
+}
+
+export interface EmailDriver {
+  name: string;
+  send(options: EmailOptions): Promise<EmailResult>;
+}
+
+export interface EmailClient {
+  send(options: EmailOptions): Promise<EmailResult>;
+}
+
+export type AwsSesConfig = {
+  region: string;
+  accessKeyId?: string;
+  secretAccessKey?: string;
+  fromEmail?: string;
+};
+
+export type MailersendConfig = {
+  apiKey: string;
+};
+
+export type NodemailerConfig = {
+  host: string;
+  port: number;
+  secure?: boolean;
+  auth?: {
+    user: string;
+    pass: string;
+  };
+};
+
+export type PostmarkConfig = {
+  apiKey: string;
+};
+
+export type ResendConfig = {
+  apiKey: string;
+};
+
+export type SendgridConfig = {
+  apiKey: string;
+};
+
+export type PlunkConfig = {
+  apiKey: string;
+};

--- a/packages/emails/tsconfig.json
+++ b/packages/emails/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@rectangular-labs/typescript/tsconfig.internal-package.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "src/templates", "src/drivers"]
+}

--- a/packages/emails/tsup.config.ts
+++ b/packages/emails/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig((options) => {
+  const isWatch = options.watch;
+  return {
+    ...options,
+    entry: ["src/index.ts"],
+    format: ["esm" as const],
+    splitting: true, //technically true by default for esm, but we'll be explicit
+    sourcemap: !isWatch,
+    minify: !isWatch,
+    clean: !isWatch,
+    onSuccess: "tsc",
+  };
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,6 +235,18 @@ importers:
         specifier: ^5.9.2
         version: 5.9.2
 
+  packages/emails:
+    devDependencies:
+      '@rectangular-labs/typescript':
+        specifier: workspace:*
+        version: link:../../tooling/typescript
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.0(jiti@2.5.1)(postcss@8.5.6)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.8.0)
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.2
+
   packages/ui:
     dependencies:
       '@hookform/resolvers':
@@ -3195,6 +3207,9 @@ packages:
     resolution: {integrity: sha512-BGcItUBWSMRgOCe+SVZJ+S7yTRG0eGt9cXAHev72yuGcY23hnLA7Bky5L/xLyPINoSN95geovfBkqoTlNZYa7w==}
     engines: {node: '>=14'}
 
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
@@ -3357,6 +3372,12 @@ packages:
   builtin-modules@3.3.0:
     resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
     engines: {node: '>=6'}
+
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
 
   c12@3.1.0:
     resolution: {integrity: sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==}
@@ -3549,6 +3570,10 @@ packages:
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
 
   common-path-prefix@3.0.0:
     resolution: {integrity: sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==}
@@ -4308,6 +4333,9 @@ packages:
     resolution: {integrity: sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g==}
     engines: {node: '>=18'}
 
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
+
   fn.name@1.1.0:
     resolution: {integrity: sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==}
 
@@ -4828,6 +4856,10 @@ packages:
   jose@5.10.0:
     resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
 
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -4978,9 +5010,20 @@ packages:
     resolution: {integrity: sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==}
     engines: {node: '>= 12.0.0'}
 
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
   listhen@1.9.0:
     resolution: {integrity: sha512-I8oW2+QL5KJo8zXNWX046M134WchxsXC7SawLPvRQpogCbkyQIaFxPE89A2HiwR7vAK2Dm2ERBAmyjTYGYEpBg==}
     hasBin: true
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   loader-runner@4.3.0:
     resolution: {integrity: sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==}
@@ -5013,6 +5056,9 @@ packages:
 
   lodash.isarguments@3.1.0:
     resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
+
+  lodash.sortby@4.7.0:
+    resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
 
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
@@ -5348,6 +5394,9 @@ packages:
 
   mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -5746,11 +5795,33 @@ packages:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
 
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
   pkg-types@2.2.0:
     resolution: {integrity: sha512-2SM/GZGAEkPp3KWORxQZns4M+WSeXbC2HEvmOIJe3Cmiv6ieAJvdVhDldtHqM5J1Y7MrR1XhkBT/rMlhh9FdqQ==}
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
 
   postcss-values-parser@6.0.2:
     resolution: {integrity: sha512-YLJpK0N1brcNJrs9WatuJFtHaV9q5aAOj+S4DI5S7jgHlRfm0PIbDCAFRYMQD5SHq7Fy6xsDhyutgS0QOAs0qw==}
@@ -6321,6 +6392,11 @@ packages:
     resolution: {integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==}
     engines: {node: '>= 8'}
 
+  source-map@0.8.0-beta.0:
+    resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
+    engines: {node: '>= 8'}
+    deprecated: The work that was done in this beta branch won't be included in future versions
+
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
@@ -6422,6 +6498,11 @@ packages:
   style-to-object@1.0.9:
     resolution: {integrity: sha512-G4qppLgKu/k6FwRpHiGiKPaPTFcG3g4wNVX/Qsfu+RqQM30E7Tyu/TEgxcL9PNLF5pdRLwQdE3YKKf+KF2Dzlw==}
 
+  sucrase@3.35.0:
+    resolution: {integrity: sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
   supports-color@10.0.0:
     resolution: {integrity: sha512-HRVVSbCCMbj7/kdWF9Q+bbckjBHLtHMEoJWlkmYzzdwhYMkjkOwubLM6t7NbWKjgKamGDrWL1++KrjUO1t9oAQ==}
     engines: {node: '>=18'}
@@ -6512,6 +6593,13 @@ packages:
   text-hex@1.0.0:
     resolution: {integrity: sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==}
 
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
@@ -6588,9 +6676,16 @@ packages:
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
+  tr46@1.0.1:
+    resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
+
   tr46@5.1.0:
     resolution: {integrity: sha512-IUWnUK7ADYR5Sl1fZlO1INDUhVhatWl7BtJWsIhwJ0UAK7ilzzIa8uIqOO/aYVWHZPJkKbEL+362wrzoeRF7bw==}
     engines: {node: '>=18'}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -6607,6 +6702,9 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
   ts-node@10.9.2:
     resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
@@ -6637,6 +6735,25 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsup@8.5.0:
+    resolution: {integrity: sha512-VmBp77lWNQq6PfuMqCHD3xWl22vEoWsKajkF8t+yMBawlUS8JzEI+vOVMeuNZIuMML8qXRizFKi9oD5glKQVcQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
 
   tsx@4.20.3:
     resolution: {integrity: sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==}
@@ -7044,6 +7161,9 @@ packages:
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
+  webidl-conversions@4.0.2:
+    resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
+
   webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
@@ -7079,6 +7199,9 @@ packages:
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
+  whatwg-url@7.1.0:
+    resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -10376,6 +10499,8 @@ snapshots:
 
   ansis@4.1.0: {}
 
+  any-promise@1.3.0: {}
+
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
@@ -10566,6 +10691,11 @@ snapshots:
       ieee754: 1.2.1
 
   builtin-modules@3.3.0: {}
+
+  bundle-require@5.1.0(esbuild@0.25.7):
+    dependencies:
+      esbuild: 0.25.7
+      load-tsconfig: 0.2.5
 
   c12@3.1.0(magicast@0.3.5):
     dependencies:
@@ -10801,6 +10931,8 @@ snapshots:
   commander@12.1.0: {}
 
   commander@2.20.3: {}
+
+  commander@4.1.1: {}
 
   common-path-prefix@3.0.0: {}
 
@@ -11498,6 +11630,12 @@ snapshots:
       path-exists: 5.0.0
       unicorn-magic: 0.1.0
 
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.17
+      mlly: 1.7.4
+      rollup: 4.45.1
+
   fn.name@1.1.0: {}
 
   follow-redirects@1.15.9(debug@4.4.0):
@@ -12076,6 +12214,8 @@ snapshots:
 
   jose@5.10.0: {}
 
+  joycon@3.1.1: {}
+
   js-tokens@4.0.0: {}
 
   js-tokens@9.0.1: {}
@@ -12209,6 +12349,10 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.30.1
       lightningcss-win32-x64-msvc: 1.30.1
 
+  lilconfig@3.1.3: {}
+
+  lines-and-columns@1.2.4: {}
+
   listhen@1.9.0:
     dependencies:
       '@parcel/watcher': 2.5.1
@@ -12229,6 +12373,8 @@ snapshots:
       ufo: 1.6.1
       untun: 0.1.3
       uqr: 0.1.2
+
+  load-tsconfig@0.2.5: {}
 
   loader-runner@4.3.0:
     optional: true
@@ -12256,6 +12402,8 @@ snapshots:
   lodash.get@4.4.2: {}
 
   lodash.isarguments@3.1.0: {}
+
+  lodash.sortby@4.7.0: {}
 
   lodash.startcase@4.4.0: {}
 
@@ -12770,6 +12918,12 @@ snapshots:
 
   mute-stream@0.0.8: {}
 
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
   nanoid@3.3.11: {}
 
   nanostores@0.11.4: {}
@@ -13251,6 +13405,8 @@ snapshots:
 
   pify@4.0.1: {}
 
+  pirates@4.0.7: {}
+
   pkg-types@1.3.1:
     dependencies:
       confbox: 0.1.8
@@ -13262,6 +13418,15 @@ snapshots:
       confbox: 0.2.2
       exsolve: 1.0.7
       pathe: 2.0.3
+
+  postcss-load-config@6.0.1(jiti@2.5.1)(postcss@8.5.6)(tsx@4.20.3)(yaml@2.8.0):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      jiti: 2.5.1
+      postcss: 8.5.6
+      tsx: 4.20.3
+      yaml: 2.8.0
 
   postcss-values-parser@6.0.2(postcss@8.5.6):
     dependencies:
@@ -13938,6 +14103,10 @@ snapshots:
 
   source-map@0.7.4: {}
 
+  source-map@0.8.0-beta.0:
+    dependencies:
+      whatwg-url: 7.1.0
+
   space-separated-tokens@2.0.2: {}
 
   spawndamnit@3.0.1:
@@ -14037,6 +14206,16 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.4
 
+  sucrase@3.35.0:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.12
+      commander: 4.1.1
+      glob: 10.4.5
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      ts-interface-checker: 0.1.13
+
   supports-color@10.0.0: {}
 
   supports-color@5.5.0:
@@ -14130,6 +14309,14 @@ snapshots:
 
   text-hex@1.0.0: {}
 
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
   through@2.3.8: {}
 
   tiny-invariant@1.3.3: {}
@@ -14193,9 +14380,15 @@ snapshots:
 
   tr46@0.0.3: {}
 
+  tr46@1.0.1:
+    dependencies:
+      punycode: 2.3.1
+
   tr46@5.1.0:
     dependencies:
       punycode: 2.3.1
+
+  tree-kill@1.2.2: {}
 
   trim-lines@3.0.1: {}
 
@@ -14206,6 +14399,8 @@ snapshots:
   ts-api-utils@2.1.0(typescript@5.9.2):
     dependencies:
       typescript: 5.9.2
+
+  ts-interface-checker@0.1.13: {}
 
   ts-node@10.9.2(@types/node@22.17.1)(typescript@5.9.2):
     dependencies:
@@ -14232,6 +14427,34 @@ snapshots:
   tslib@1.14.1: {}
 
   tslib@2.8.1: {}
+
+  tsup@8.5.0(jiti@2.5.1)(postcss@8.5.6)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.8.0):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.25.7)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.1
+      esbuild: 0.25.7
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(jiti@2.5.1)(postcss@8.5.6)(tsx@4.20.3)(yaml@2.8.0)
+      resolve-from: 5.0.0
+      rollup: 4.45.1
+      source-map: 0.8.0-beta.0
+      sucrase: 3.35.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.14
+      tree-kill: 1.2.2
+    optionalDependencies:
+      postcss: 8.5.6
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
 
   tsx@4.20.3:
     dependencies:
@@ -14646,6 +14869,8 @@ snapshots:
 
   webidl-conversions@3.0.1: {}
 
+  webidl-conversions@4.0.2: {}
+
   webidl-conversions@7.0.0: {}
 
   webpack-sources@3.2.3:
@@ -14699,6 +14924,12 @@ snapshots:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
+
+  whatwg-url@7.1.0:
+    dependencies:
+      lodash.sortby: 4.7.0
+      tr46: 1.0.1
+      webidl-conversions: 4.0.2
 
   which@2.0.2:
     dependencies:


### PR DESCRIPTION
- Core: createEmailClient with unified send interface
- Drivers: AWS SES, MailerSend, Nodemailer, Postmark, Resend, SendGrid, Plunk
- Templates: Magic link, OTP, password reset, welcome, user invite, verification. Using JSX email templates via @jsx-email/all components
- Type-safe with optional peer dependencies for tree-shaking 

🤖 Generated with [Claude Code](https://claude.ai/code)